### PR TITLE
Own the gammu state machine on a single worker thread

### DIFF
--- a/sms-gammu-gateway/Dockerfile
+++ b/sms-gammu-gateway/Dockerfile
@@ -31,6 +31,7 @@ RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
 # Copy application files
 COPY run.py .
 COPY support.py .
+COPY gammu_worker.py .
 COPY urc_filter.py .
 COPY mqtt_publisher.py .
 COPY config.json .

--- a/sms-gammu-gateway/gammu_worker.py
+++ b/sms-gammu-gateway/gammu_worker.py
@@ -1,0 +1,264 @@
+"""Synchronous facade over gammu.asyncworker.GammuAsyncWorker.
+
+python-gammu's StateMachine is not thread safe, and a call blocked inside libGammu
+cannot be cancelled from Python. The previous design submitted every operation to a
+throwaway ThreadPoolExecutor and, on timeout, called shutdown(wait=False): the timed
+out call kept running against the serial port while the lock it was nominally
+protected by had already been released, so the next operation ran concurrently with
+it. That is a data race on both the port and libGammu's internal state.
+
+GammuAsyncWorker owns the StateMachine on a single thread for the process lifetime
+and feeds it from a queue. A stalled call therefore delays queued work instead of
+running alongside it. Nothing else ever touches the StateMachine.
+
+The add-on is threaded rather than asyncio, so the worker runs on a private event
+loop in a dedicated thread and callers submit work with run_coroutine_threadsafe.
+Attribute access returns a callable that dispatches the matching StateMachine method
+by name, so existing `machine.SendSMS(...)` call sites work unchanged.
+
+Owning the queue is also what makes recovery possible. A caller that gives up cancels
+its command, so an abandoned backlog is dropped rather than replayed against a modem
+that has just come back. And because a worker that never returns would swallow every
+later command -- including the soft reset that recovers the modem -- a run of
+consecutive timeouts exits the process so the Supervisor restarts the add-on.
+
+Re-entrancy: incoming SMS and call callbacks registered with SetIncomingCallback are
+invoked *on the worker thread*, from inside ReadDevice. A callback that calls back
+into this proxy would enqueue work behind itself and block forever. Callbacks must
+hand off to another thread; mqtt_publisher does this with a threading.Timer.
+"""
+
+import asyncio
+import logging
+import os
+import threading
+
+import gammu
+import gammu.worker
+from gammu.asyncworker import GammuAsyncThread, GammuAsyncWorker
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on queue wait plus execution for a single command. gammu's own
+# commtimeout cannot serve here for two reasons: SetConfig rejects any key outside
+# {Model, DebugLevel, Device, Connection, DebugFile, UseGlobalDebugFile, LockDevice,
+# StartInfo, SyncTime} with ValueError, and libGammu never reads commtimeout anyway
+# -- it appears only in smsd/core.c, the SMS daemon's own configuration.
+DEFAULT_TIMEOUT = int(os.environ.get("GAMMU_COMMAND_TIMEOUT", "60"))
+
+# Init and Terminate talk to the modem, so they get the same allowance as any other
+# command rather than a short startup timeout.
+STARTUP_TIMEOUT = 60
+
+# Consecutive timeouts before the add-on gives up and restarts. libGammu normally
+# bounds its own waits -- the SMS prompt stall returns TIMEOUT[14] after 29s -- and
+# the queue drains once it does. A worker that never returns is a different failure:
+# every later command times out behind it, including the soft reset that would
+# otherwise recover the modem. Nothing inside the process can clear that, because the
+# stuck call cannot be interrupted from Python.
+#
+# Both this and DEFAULT_TIMEOUT read the environment so the end-to-end tests can
+# reach the give-up path in seconds instead of three minutes. Operators can use
+# them too: a slow modem on a long multipart send may want a larger timeout.
+STALL_LIMIT = int(os.environ.get("GAMMU_STALL_LIMIT", "3"))
+
+# EX_SOFTWARE. Any non-zero exit makes the Supervisor restart the add-on.
+STALL_EXIT_CODE = 70
+
+
+def restart_process(timeouts):
+    """Exit so the Supervisor restarts the add-on.
+
+    os._exit rather than sys.exit: this runs on a caller's thread, and SystemExit
+    raised off the main thread only unwinds that thread. The gammu thread is blocked
+    inside libGammu and cannot be joined, so an orderly shutdown is not on offer.
+    Logging is flushed first because os._exit skips interpreter cleanup.
+    """
+    logger.critical(
+        "Gammu worker stalled for %d consecutive commands; restarting the add-on", timeouts
+    )
+    logging.shutdown()
+    os._exit(STALL_EXIT_CODE)
+
+
+class _ExceptionPreservingThread(GammuAsyncThread):
+    """Worker thread that reports the original gammu exception.
+
+    GammuAsyncThread._do_command converts a GSMError into its error *name* and
+    GammuAsyncWorker.worker_callback re-wraps that string as a plain gammu.GSMError,
+    which discards the specific subclass. Callers written against python-gammu expect
+    to catch gammu.ERR_NOSIM or gammu.ERR_NOTSUPPORTED, and support.py does exactly
+    that. Passing the exception object through keeps `except gammu.ERR_*` working,
+    along with the error dict in args[0].
+    """
+
+    def _do_command(self, future, cmd, params, percentage=100):
+        # A caller that timed out cancels its future. Running the command anyway would
+        # drive the modem for a result nobody is waiting for, and after a long stall
+        # the entire backlog would replay in a burst against a modem that just came
+        # back. Init and Terminate arrive as plain strings and are never skipped.
+        #
+        # Reading cancelled() from this thread is a state read on the asyncio future;
+        # the worst case is executing a command abandoned microseconds earlier.
+        if hasattr(future, "cancelled") and future.cancelled():
+            logger.debug("Skipping abandoned gammu command %s", cmd)
+            return
+
+        func = getattr(self._sm, cmd)
+        try:
+            result = gammu.worker._execute_command(func, params)
+        except Exception as exception:  # noqa: BLE001 - relayed to the caller verbatim
+            self._callback(future, None, exception, percentage)
+        else:
+            self._callback(future, result, None, percentage)
+
+
+class _Worker(GammuAsyncWorker):
+    """GammuAsyncWorker using the exception preserving thread."""
+
+    def worker_callback(self, name, result, error, percents):
+        """Deliver a result, unless the caller has already given up on it.
+
+        A command that was mid-flight when its caller timed out still runs to
+        completion, and the base implementation would then call set_result on a
+        cancelled future -- InvalidStateError, once per timeout, surfacing as a
+        loop exception rather than anywhere useful. The check runs on the loop
+        thread so it cannot race the cancellation it is testing for.
+        """
+        if not hasattr(name, "set_result"):
+            super().worker_callback(name, result, error, percents)
+            return
+
+        def deliver():
+            if name.done():
+                logger.debug("Discarding gammu result for an abandoned command")
+            elif error is None:
+                name.set_result(result)
+            elif isinstance(error, Exception):
+                name.set_exception(error)
+            else:
+                name.set_exception(gammu.GSMError(error))
+
+        self._loop.call_soon_threadsafe(deliver)
+
+    async def init_async(self):
+        self._init_future = self._loop.create_future()
+        self._thread = _ExceptionPreservingThread(
+            self._queue, self._config, self._callback, self._pull_func
+        )
+        self._thread.start()
+        await self._init_future
+        self._init_future = None
+
+
+class GammuWorkerProxy:
+    """Presents the StateMachine API, executes every call on the worker thread."""
+
+    def __init__(
+        self,
+        config,
+        timeout=DEFAULT_TIMEOUT,
+        worker_factory=_Worker,
+        stall_limit=STALL_LIMIT,
+        on_stall=restart_process,
+    ):
+        self._timeout = timeout
+        self._worker_factory = worker_factory
+        self._stall_limit = stall_limit
+        self._on_stall = on_stall
+        self._timeouts = 0
+        self._timeouts_lock = threading.Lock()
+        self._loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run_loop, name="gammu-loop", daemon=True)
+        self._thread.start()
+        self._ready.wait()
+
+        # GammuAsyncWorker.__init__ calls asyncio.get_event_loop(), which outside a
+        # running loop is deprecated in 3.10+ and an error in 3.14. Constructing it
+        # inside a coroutine means get_event_loop() returns our running loop.
+        self._worker = self._submit(self._create(config), STARTUP_TIMEOUT)
+
+    def init(self):
+        """Connect to the phone.
+
+        Separate from construction so a caller can tolerate an Init failure and keep
+        using the proxy, which is what support.py does for a missing SIM. The worker
+        thread survives a failed Init and stays ready for further commands.
+        """
+        self._submit(self._worker.init_async(), STARTUP_TIMEOUT)
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._ready.set()
+        self._loop.run_forever()
+
+    def _submit(self, coro, timeout):
+        pending = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            result = pending.result(timeout)
+        except TimeoutError:
+            # Cancelling drops the command if the worker has not reached it yet; a
+            # command already executing runs to completion, because libGammu cannot
+            # be interrupted. Either way it never races the next one.
+            pending.cancel()
+            pending.add_done_callback(self._discard_late_result)
+            self._record_timeout()
+            raise
+        else:
+            self._record_success()
+            return result
+
+    def _record_timeout(self):
+        with self._timeouts_lock:
+            self._timeouts += 1
+            timeouts = self._timeouts
+        if self._stall_limit and timeouts >= self._stall_limit:
+            self._on_stall(timeouts)
+
+    def _record_success(self):
+        with self._timeouts_lock:
+            self._timeouts = 0
+
+    @staticmethod
+    def _discard_late_result(pending):
+        try:
+            pending.result()
+        except (Exception, asyncio.CancelledError) as exc:  # noqa: BLE001 - caller gave up
+            logger.debug("Late gammu result discarded: %s", type(exc).__name__)
+
+    async def _create(self, config):
+        worker = self._worker_factory()
+        worker.configure(config)
+        return worker
+
+    async def _dispatch(self, name, args, kwargs):
+        future = self._loop.create_future()
+        # GammuThread._execute_command calls func(**params) for a dict, func(*params)
+        # for anything else, and func() for None. It cannot do both at once.
+        if args and kwargs:
+            raise TypeError(f"{name}() takes positional or keyword arguments, not both")
+        self._worker.enqueue(future, commands=[(name, kwargs if kwargs else args)])
+        return await future
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def call(*args, **kwargs):
+            return self._submit(self._dispatch(name, args, kwargs), self._timeout)
+
+        call.__name__ = name
+        return call
+
+    def terminate(self):
+        """Stop the worker thread and the private event loop."""
+        try:
+            if self._worker is not None:
+                self._submit(self._worker.terminate_async(), STARTUP_TIMEOUT)
+        except Exception:
+            logger.exception("Gammu worker did not terminate cleanly")
+        finally:
+            self._worker = None
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)

--- a/sms-gammu-gateway/mqtt_publisher.py
+++ b/sms-gammu-gateway/mqtt_publisher.py
@@ -214,12 +214,7 @@ class MQTTPublisher:
         self.device_id = config.get('mqtt_device_id', 'sms_gateway')
         self.availability_topic = f"{self.topic_prefix}/availability"  # Shared availability for all entities
         self.gammu_machine = None  # Will be set externally
-        # Every gammu call runs on this one thread, which owns the StateMachine.
-        # python-gammu's StateMachine is not thread safe and a call blocked inside
-        # libGammu cannot be cancelled, so single ownership is what keeps a stall
-        # contained instead of corrupting state shared with other threads.
-        self._gammu_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="gammu")
+        self.gammu_lock = threading.Lock()  # Serialize all Gammu operations to prevent race conditions
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
         self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
@@ -1658,10 +1653,11 @@ class MQTTPublisher:
                         if self._is_call_active():
                             time.sleep(1)
                             continue
-                        # Re-check before queueing to avoid racing DialVoice
-                        if self._is_call_active():
-                            continue
-                        self._gammu_executor.submit(gammu_machine.ReadDevice).result(timeout=10)
+                        with self.gammu_lock:
+                            # Re-check inside lock to prevent race with DialVoice
+                            if self._is_call_active():
+                                continue
+                            gammu_machine.ReadDevice()
                     except Exception as e:
                         logger.debug(f"ReadDevice: {e}")
 
@@ -1670,12 +1666,10 @@ class MQTTPublisher:
                         self._post_call_recovery_until = None
                         logger.info("🔄 Post-call recovery: re-initializing modem connection...")
                         try:
-                            def _reinit_state_machine():
+                            with self.gammu_lock:
                                 gammu_machine.Terminate()
                                 time.sleep(2)
                                 gammu_machine.Init()
-
-                            self._gammu_executor.submit(_reinit_state_machine).result(timeout=60)
                             logger.info("✅ Modem connection re-initialized")
                             # Re-register callbacks (lost after Terminate+Init)
                             from support import setupCallbacks
@@ -1733,35 +1727,40 @@ class MQTTPublisher:
         if self._is_post_call_recovery() and operation_name != "Reset":
             logger.debug(f"⏸️ Skipping '{operation_name}' - post-call recovery in progress")
             raise Exception("Post-call recovery in progress, modem busy")
-        # Submitting to the single-worker executor is what serializes operations:
-        # only the owner thread ever touches the StateMachine, so a stalled call
-        # delays queued work rather than racing with it.
-        future = self._gammu_executor.submit(gammu_function, *args, **kwargs)
-        try:
-            # Python-level timeout (60s) as second defense layer
-            # Primary defense is Gammu commtimeout=40s in config
-            result = future.result(timeout=60)
-            self.device_tracker.record_success()
-            self.publish_device_status()
-            logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
+        # The gammu worker thread owns the state machine and executes one command at a
+        # time, so this lock no longer protects the serial port — the worker does that
+        # unconditionally, including against callers that forget to take a lock. What
+        # it still does is keep multi-step sequences coherent: retrieveAllSms walks the
+        # SIM with GetSMSStatus followed by repeated GetNextSMS, and a delete arriving
+        # between those commands would renumber locations mid-enumeration.
+        #
+        # Timeouts are enforced per command inside GammuWorkerProxy. The executor that
+        # used to provide them was actively harmful: shutdown(wait=False) let a timed
+        # out call keep running against the port after the lock was released, so the
+        # next operation raced it.
+        with self.gammu_lock:
+            try:
+                result = gammu_function(*args, **kwargs)
+                self.device_tracker.record_success()
+                self.publish_device_status()
+                logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
 
-            # Small delay after each operation to let modem "breathe"
-            # Prevents buffer overflow on modems like Huawei E1750
-            time.sleep(0.3)
+                # Small delay after each operation to let modem "breathe"
+                # Prevents buffer overflow on modems like Huawei E1750
+                time.sleep(0.3)
 
-            return result
-        except concurrent.futures.TimeoutError:
-            # The call is still running on the owner thread. Queued operations wait
-            # their turn rather than entering a StateMachine that is still in use.
-            self.device_tracker.record_failure(f"{operation_name}: Python timeout (60s)")
-            self.publish_device_status()
-            logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 60s")
-            raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 60s")
-        except Exception as e:
-            # All other errors (including Gammu commtimeout errors)
-            self.device_tracker.record_failure(f"{operation_name}: {str(e)}")
-            self.publish_device_status()
-            raise
+                return result
+            except TimeoutError:
+                # The command is still queued on the worker thread; later commands wait
+                # behind it rather than running concurrently with it.
+                self.device_tracker.record_failure(f"{operation_name}: gammu worker timeout")
+                self.publish_device_status()
+                logger.error(f"⏱️ Gammu operation '{operation_name}' timed out")
+                raise
+            except Exception as e:
+                self.device_tracker.record_failure(f"{operation_name}: {str(e)}")
+                self.publish_device_status()
+                raise
     
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""

--- a/sms-gammu-gateway/mqtt_publisher.py
+++ b/sms-gammu-gateway/mqtt_publisher.py
@@ -214,7 +214,12 @@ class MQTTPublisher:
         self.device_id = config.get('mqtt_device_id', 'sms_gateway')
         self.availability_topic = f"{self.topic_prefix}/availability"  # Shared availability for all entities
         self.gammu_machine = None  # Will be set externally
-        self.gammu_lock = threading.Lock()  # Serialize all Gammu operations to prevent race conditions
+        # Every gammu call runs on this one thread, which owns the StateMachine.
+        # python-gammu's StateMachine is not thread safe and a call blocked inside
+        # libGammu cannot be cancelled, so single ownership is what keeps a stall
+        # contained instead of corrupting state shared with other threads.
+        self._gammu_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="gammu")
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
         self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
@@ -1653,11 +1658,10 @@ class MQTTPublisher:
                         if self._is_call_active():
                             time.sleep(1)
                             continue
-                        with self.gammu_lock:
-                            # Re-check inside lock to prevent race with DialVoice
-                            if self._is_call_active():
-                                continue
-                            gammu_machine.ReadDevice()
+                        # Re-check before queueing to avoid racing DialVoice
+                        if self._is_call_active():
+                            continue
+                        self._gammu_executor.submit(gammu_machine.ReadDevice).result(timeout=10)
                     except Exception as e:
                         logger.debug(f"ReadDevice: {e}")
 
@@ -1666,10 +1670,12 @@ class MQTTPublisher:
                         self._post_call_recovery_until = None
                         logger.info("🔄 Post-call recovery: re-initializing modem connection...")
                         try:
-                            with self.gammu_lock:
+                            def _reinit_state_machine():
                                 gammu_machine.Terminate()
                                 time.sleep(2)
                                 gammu_machine.Init()
+
+                            self._gammu_executor.submit(_reinit_state_machine).result(timeout=60)
                             logger.info("✅ Modem connection re-initialized")
                             # Re-register callbacks (lost after Terminate+Init)
                             from support import setupCallbacks
@@ -1727,37 +1733,35 @@ class MQTTPublisher:
         if self._is_post_call_recovery() and operation_name != "Reset":
             logger.debug(f"⏸️ Skipping '{operation_name}' - post-call recovery in progress")
             raise Exception("Post-call recovery in progress, modem busy")
-        # Use lock to serialize all Gammu operations (prevent race conditions on serial port)
-        with self.gammu_lock:
-            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            future = executor.submit(gammu_function, *args, **kwargs)
-            try:
-                # Python-level timeout (60s) as second defense layer
-                # Primary defense is Gammu commtimeout=40s in config
-                result = future.result(timeout=60)
-                self.device_tracker.record_success()
-                self.publish_device_status()
-                logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
+        # Submitting to the single-worker executor is what serializes operations:
+        # only the owner thread ever touches the StateMachine, so a stalled call
+        # delays queued work rather than racing with it.
+        future = self._gammu_executor.submit(gammu_function, *args, **kwargs)
+        try:
+            # Python-level timeout (60s) as second defense layer
+            # Primary defense is Gammu commtimeout=40s in config
+            result = future.result(timeout=60)
+            self.device_tracker.record_success()
+            self.publish_device_status()
+            logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
 
-                # Small delay after each operation to let modem "breathe"
-                # Prevents buffer overflow on modems like Huawei E1750
-                time.sleep(0.3)
+            # Small delay after each operation to let modem "breathe"
+            # Prevents buffer overflow on modems like Huawei E1750
+            time.sleep(0.3)
 
-                return result
-            except concurrent.futures.TimeoutError:
-                # Operation timed out at Python level
-                self.device_tracker.record_failure(f"{operation_name}: Python timeout (60s)")
-                self.publish_device_status()
-                logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 60s")
-                raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 60s")
-            except Exception as e:
-                # All other errors (including Gammu commtimeout errors)
-                self.device_tracker.record_failure(f"{operation_name}: {str(e)}")
-                self.publish_device_status()
-                raise
-            finally:
-                # Never wait for stuck threads — prevents deadlock when Gammu hangs on serial port
-                executor.shutdown(wait=False)
+            return result
+        except concurrent.futures.TimeoutError:
+            # The call is still running on the owner thread. Queued operations wait
+            # their turn rather than entering a StateMachine that is still in use.
+            self.device_tracker.record_failure(f"{operation_name}: Python timeout (60s)")
+            self.publish_device_status()
+            logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 60s")
+            raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 60s")
+        except Exception as e:
+            # All other errors (including Gammu commtimeout errors)
+            self.device_tracker.record_failure(f"{operation_name}: {str(e)}")
+            self.publish_device_status()
+            raise
     
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""

--- a/sms-gammu-gateway/support.py
+++ b/sms-gammu-gateway/support.py
@@ -11,43 +11,41 @@ import os
 import logging
 import gammu
 
+from gammu_worker import GammuWorkerProxy
+
 
 def init_state_machine(pin, device_path='/dev/ttyUSB0', baud_rate='auto'):
-    """Initialize gammu state machine with HA add-on config.
+    """Initialize the gammu worker with HA add-on config.
+
+    Returns a GammuWorkerProxy rather than a bare StateMachine. The proxy exposes the
+    StateMachine API by name and executes every call on a single thread that owns the
+    state machine, which is what makes concurrent use from Flask handlers, the MQTT
+    loops and the ReadDevice loop safe. Call sites are unchanged.
 
     baud_rate: 'auto' ponechá gammu auto-detekci rychlosti (connection = at),
     konkrétní hodnota (např. '115200') rychlost zafixuje (connection = at115200).
     Auto-detekce zasekává některé moduly (SIM800C) → default je fixní rychlost.
     """
-    sm = gammu.StateMachine()
-
     # Rychlost: 'auto' -> at (gammu hádá), jinak at<rychlost> (fixní)
     if baud_rate and str(baud_rate) != 'auto':
         connection = f"at{baud_rate}"
     else:
         connection = "at"
 
-    # Create gammu config dynamically
-    config_content = f"""[gammu]
-device = {device_path}
-connection = {connection}
-commtimeout = 40
-"""
+    # SetConfig replaces the gammurc file that used to be written to /tmp. Nothing is
+    # lost in the move: that file also set commtimeout = 40, which libGammu never
+    # reads. The option belongs to gammu-smsd (smsd/core.c) and has no effect here.
+    config = {"Device": device_path, "Connection": connection}
 
-    # Write config to temporary file
-    config_file = '/tmp/gammu.config'
-    with open(config_file, 'w') as f:
-        f.write(config_content)
+    machine = GammuWorkerProxy(config)
 
-    sm.ReadConfig(Filename=config_file)
-    
     try:
-        sm.Init()
+        machine.init()
         logging.info(f"Successfully initialized gammu with device: {device_path}")
 
         # Try to check security status
         try:
-            security_status = sm.GetSecurityStatus()
+            security_status = machine.GetSecurityStatus()
             logging.info(f"SIM security status: {security_status}")
 
             if security_status == 'PIN':
@@ -55,13 +53,14 @@ commtimeout = 40
                     logging.error("PIN is required but not provided.")
                     sys.exit(1)
                 else:
-                    sm.EnterSecurityCode('PIN', pin)
+                    machine.EnterSecurityCode('PIN', pin)
                     logging.info("PIN entered successfully")
 
         except Exception as e:
             logging.warning(f"Could not check SIM security status: {e}")
 
     except gammu.ERR_NOSIM:
+        # The worker thread survives a failed Init, so the proxy stays usable.
         logging.warning("SIM card not accessible, but device is connected")
     except Exception as e:
         logging.error(f"Error initializing device: {e}")
@@ -70,9 +69,11 @@ commtimeout = 40
             logging.info(f"Available devices: {', '.join([f'/dev/{d}' for d in sorted(devices)[:10]])}")
         except:
             pass
+        # Do not leak the worker thread and its event loop on a failed startup.
+        machine.terminate()
         raise
-        
-    return sm
+
+    return machine
 
 
 def retrieveAllSms(machine):


### PR DESCRIPTION
Fixes #51.

## The problem

`track_gammu_operation` creates a `ThreadPoolExecutor` per call and, on timeout, calls
`shutdown(wait=False)`:

```python
with self.gammu_lock:
    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
    future = executor.submit(gammu_function, *args, **kwargs)
    try:
        result = future.result(timeout=60)
    finally:
        executor.shutdown(wait=False)
```

A call blocked inside libGammu cannot be cancelled from Python. `shutdown(wait=False)` does not stop
it — it stops waiting for it. When the 60s timeout fires, the `with` block releases the lock while
that call is **still driving the serial port**, and the next operation begins on a `StateMachine`
that is in use. `StateMachine` is not thread safe, so this races both the port and libGammu's
internal state.

To be precise about when it bites: for stalls shorter than 60s the lock is held throughout and
everything is fine. It needs a stall past the Python timeout, which is what a modem that stops
answering mid-transaction produces. From there every later operation runs on top of a call still in
flight — including the soft reset in the SMS monitor loop that exists to recover the modem — so
failures cascade instead of clearing.

## The change

Use **`gammu.asyncworker.GammuAsyncWorker`**, python-gammu's own facility for this: one thread owns
the `StateMachine` for the process lifetime and takes commands from a queue.

`GammuWorkerProxy` (new, `gammu_worker.py`) runs it on a private event loop and exposes the
`StateMachine` API by attribute name, so **every existing call site is unchanged** —
`machine.SendSMS(...)`, `machine.GetSMSStatus()`, `retrieveAllSms(machine)` all work as before.

A stalled command now delays queued work instead of racing it. Nothing else ever touches the state
machine.

### Two details the migration needs

**Error classes.** `GammuAsyncThread._do_command` converts a `GSMError` into its error *name*, and
`worker_callback` re-wraps that string as a plain `gammu.GSMError`, discarding the subclass.
`support.py` catches `gammu.ERR_NOSIM` and `gammu.ERR_NOTSUPPORTED` by class, so this would have
silently stopped matching. The thread is subclassed to relay the original exception object.

**Config.** `SetConfig` replaces the gammurc written to `/tmp`. It rejects any key outside its fixed
set, so `commtimeout = 40` cannot come along. Nothing is lost — **libGammu never read it.** That
option appears only in `smsd/core.c`, gammu-smsd's own configuration. (The existing comment calling
it the "primary defense" is inaccurate; I left it alone rather than widen this diff.)

### Recovery uses the queue

- a caller that times out **cancels** its command, so an abandoned backlog is dropped rather than
  replayed against a modem that has only just come back
- a result arriving for a cancelled future is discarded **on the loop thread**, avoiding
  `InvalidStateError` once per timeout
- a run of consecutive timeouts exits with `EX_SOFTWARE` so the Supervisor restarts the add-on —
  the only remaining move when a call never returns and even the soft reset is queued behind it.
  Thresholds are `GAMMU_COMMAND_TIMEOUT` and `GAMMU_STALL_LIMIT`, defaulting to 60s and 3.

`gammu_lock` is kept, now documented for what it actually does: keeping multi-step sequences such as
`retrieveAllSms` coherent. It no longer pretends to protect the port; the worker does that
unconditionally, including against callers that forget to take a lock.

### Dockerfile

`gammu_worker.py` is added to the `COPY` list. Worth calling out because I hit it: the modules are
copied one by one, and omitting the new one yields an image that builds, starts, and then dies
importing a module that is not in it.

## Verification

- **Running in production** on a SIMCom SIM7670G (AT&T), sending and receiving normally
- **44 unit tests** against gammu's `dummy` driver, so they need no modem and run anywhere:
  [`tests/test_gammu_worker.py`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/main/sms-gammu-gateway/tests/test_gammu_worker.py)
  covers concurrent callers, error-class preservation, a timed-out command that is neither
  cancelled nor overlapped, and a stub worker that blocks indefinitely so the give-up path is
  reached deterministically.
  [`tests/test_support_gammu.py`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/main/sms-gammu-gateway/tests/test_support_gammu.py)
  exercises `encodeSms`, `retrieveAllSms` and `deleteSms` unchanged through the proxy. The dummy
  phone is set up in
  [`tests/conftest.py`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/main/sms-gammu-gateway/tests/conftest.py)
  in about twenty lines.
- **End-to-end** inside the built image against a pseudo-terminal fake modem
  ([`tests/e2e/fake_modem.py`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/main/sms-gammu-gateway/tests/e2e/fake_modem.py),
  [`tests/e2e/send_sms_e2e.py`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/main/sms-gammu-gateway/tests/e2e/send_sms_e2e.py)),
  so libGammu's parser and the real HTTP API are in the loop: a modem that fails then recovers must
  send again **in the same process**; concurrent callers must not interleave (verified from the
  modem side — a PDU is hex, so `AT` cannot appear inside one); a modem that never answers must
  exit rather than wedge. The fake modem also answers enough AT to complete libGammu's init
  handshake, which makes "cannot send" reproducible without hardware.

Both suites run from
[`.github/workflows/ci.yml`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml):
the unit tests under `pytest` with `libgammu-dev` installed, the end-to-end steps against the image
the build job produces.

They are not part of this PR.
Each of these is a step in the build job, run against the image that job just produced:

| # | E2E step | What it pins | Implementation |
|---|---|---|---|
| 1 | [standard prompt sends](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L63) | baseline: a well formed "> " prompt sends | [`PROMPT_PADDED`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/fake_modem.py#L25) |
| 2 | [bare prompt sends](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L72) | a modem sending a bare ">" still sends — the SIM7670G case | [`PROMPT_BARE`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/fake_modem.py#L28) |
| 3 | [corrupt prompt fails without sending](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L80) | ">@" must never be accepted, and no PDU may reach the modem | [`PROMPT_GARBAGE`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/fake_modem.py#L32) |
| 4 | [silent modem fails without sending](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L86) | modem stops answering mid-transaction | [`PROMPT_SILENT`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/fake_modem.py#L35) |
| 5 | [recovers in place once the modem behaves](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L94) | after a failing stretch the **next send succeeds in the same process** — no restart needed. Runs with the SMS monitor loop enabled, since the soft reset lives there | [`scenario_recovery`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/send_sms_e2e.py#L113) |
| 6 | [concurrent callers never interleave](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L103) | three callers during a stall never overlap on the port, and the port still works afterwards | [`scenario_concurrent`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/send_sms_e2e.py#L147) |
| 7 | [a modem that never answers restarts the add-on](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/.github/workflows/ci.yml#L113) | the give-up path: exits `EX_SOFTWARE` rather than waiting behind a call that cannot be interrupted | [`scenario_watchdog`](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/blob/31a0793c034fe8464216c614d925a9e560c4f606/sms-gammu-gateway/tests/e2e/send_sms_e2e.py#L184) |

Steps 5 to 7 are the ones relevant to this change. A [green run of all seven](https://github.com/HomeOps/HASS-SMS-Gammu-Gateway/actions/runs/31334985618).

Interleaving in step 6 is detected from the modem's side rather than inferred: a PDU is hex, so
`AT` cannot occur inside one, and those two bytes appearing in a message body mean a second caller
reached the port mid-transaction.


## Things you may want to push back on

- The watchdog exits the process (`os._exit`). That is deliberate — `SystemExit` off the main thread
  only unwinds that thread, and the gammu thread cannot be joined — but it is opinionated, and I am
  happy to make it log-and-continue instead if you prefer.
- The private event loop thread exists because the add-on is threaded rather than asyncio. If you
  would rather not carry an event loop, `gammu.worker.GammuWorker` gives the same single-owner
  guarantee with callbacks instead; say the word and I will switch it.

## Related

gammu/gammu#1177, merged upstream 2026-08-09: released libGammu accepts an SMS edit prompt only as
`"> "`, and Qualcomm-based modules such as the SIM7670G send a bare `">"`, so every send fails with
`TIMEOUT[14]` while the modem reports healthy. Separate from this issue, but identical in the logs —
worth knowing when triaging "cannot send" reports on newer LTE hardware.
